### PR TITLE
docs: change old ADGUARD_HOME variable name to new ADGUARD_URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ sidecars:
     env:
       - name: LOG_LEVEL
         value: debug
-      - name: ADGUARD_HOME
+      - name: ADGUARD_URL
         valueFrom:
           secretKeyRef:
             name: adguard-configuration


### PR DESCRIPTION
It seems like the README.md file has become a bit outdated.

I tried to follow the installation guide and encountered an error from the provider sidecar container: `{"level":"fatal","msg":"failed to initialize provider: reading adguard configuration failed: env: environment variable \"ADGUARD_URL\" should not be empty","time":"2024-02-18T11:38:15Z"}`.

It appears that the variable for the AdGuard endpoint has changed, so I have made the necessary corrections in the README.md file.